### PR TITLE
Updated link to your DockerHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ python3 -m pip install snakemake==6.15.5
 bsub -q general -G <COMPUTE_ALLOCATION> -a 'docker(thatdnaguy/ubuntu:latest)' CMD
 ```
 
-The images themselves can be found on my [Dockerhub](https://hub.docker.com/repositories/thatdnaguy) account. The Ubuntu image is based on release 18 and includes Python v3.6, Snakemake v6.15.5, and pigz.
+The images themselves can be found on my [DockerHub](https://hub.docker.com/u/thatdnaguy) account. The Ubuntu image is based on release 18 and includes Python v3.6, Snakemake v6.15.5, and pigz.


### PR DESCRIPTION
I think the previous URL was private (or I at least needed to sign into DockerHub). This one is publicly accessible without needing to sign in